### PR TITLE
Reloader improvements

### DIFF
--- a/CombatRealism/Reload/CompReloader.cs
+++ b/CombatRealism/Reload/CompReloader.cs
@@ -12,6 +12,7 @@ namespace Combat_Realism
     {
         public int roundPerMag = 1;
         public int reloadTick = 300;
+        public bool throwMote = true;
     }
 
     public class CompReloader : CommunityCoreLibrary.CompRangedGizmoGiver
@@ -71,8 +72,15 @@ namespace Combat_Realism
                 return;
             }
 #endif
-            MoteThrower.ThrowText( Wielder.Position.ToVector3Shifted(), "CR_ReloadingMote".Translate() );
-            var job = new Job( DefDatabase< JobDef >.GetNamed( "ReloadWeapon" ), Wielder, parent );
+            if ( reloaderProp.throwMote )
+            {
+                MoteThrower.ThrowText( Wielder.Position.ToVector3Shifted(), "CR_ReloadingMote".Translate() );
+            }
+            var job = new Job( DefDatabase< JobDef >.GetNamed( "ReloadWeapon" ), Wielder, parent )
+            {
+                playerForced = true
+                
+            };
 
             if ( Wielder.drafter != null )
             {
@@ -86,8 +94,11 @@ namespace Combat_Realism
     
         public void FinishReload()
         {
-            parent.def.soundInteract.PlayOneShot(SoundInfo.InWorld(parent.Position));
-            MoteThrower.ThrowText( Wielder.Position.ToVector3Shifted(), "CR_ReloadedMote".Translate() );
+            parent.def.soundInteract.PlayOneShot(SoundInfo.InWorld(Wielder.Position));
+            if ( reloaderProp.throwMote )
+            {
+                MoteThrower.ThrowText(Wielder.Position.ToVector3Shifted(), "CR_ReloadedMote".Translate());
+            }
             count = reloaderProp.roundPerMag;
             needReload = false;
         }

--- a/CombatRealism/Reload/JobDriver_Reload.cs
+++ b/CombatRealism/Reload/JobDriver_Reload.cs
@@ -16,14 +16,9 @@ namespace Combat_Realism
         protected override IEnumerable< Toil > MakeNewToils()
         {
             this.FailOnBroken( TargetIndex.A );
-            
-            //Toil of do-nothing
-            var waitToil = new Toil();
-            waitToil.initAction = () => waitToil.actor.pather.StopDead();
-            waitToil.defaultCompleteMode = ToilCompleteMode.Delay;
-            waitToil.defaultDuration = CompReloader.reloaderProp.reloadTick;
 
-            yield return waitToil;
+            //Toil of do-nothing
+            pawn.stances.SetStance(new Stance_Cooldown(CompReloader.reloaderProp.reloadTick, TargetInfo.Invalid));
 
             //Actual reloader
             var reloadToil = new Toil();


### PR DESCRIPTION
* Set _throwMote_ false to prevent reloader throw any text mote.
 * Neolithic reloading motes are being thrown too frequently.
* Fixed NPCs sometimes reload endlessly, by making reload job more forceful.
* Reloading pawns will draw cooldown pie on them if clicked.