### PR TITLE
Remove stance

### DIFF
--- a/CombatRealism/Reload/CompReloader.cs
+++ b/CombatRealism/Reload/CompReloader.cs
@@ -59,12 +59,6 @@ namespace Combat_Realism
             count = 0;
             needReload = true;
 #if DEBUG
-            if ( CompEquippable == null )
-            {
-                Log.ErrorOnce( "CompEquippable of " + parent + " is null!", 7381888 );
-                FinishReload();
-                return;
-            }
             if ( Wielder == null )
             {
                 Log.ErrorOnce( "Wielder of " + parent + " is null!", 7381889 );
@@ -76,10 +70,10 @@ namespace Combat_Realism
             {
                 MoteThrower.ThrowText( Wielder.Position.ToVector3Shifted(), "CR_ReloadingMote".Translate() );
             }
+
             var job = new Job( DefDatabase< JobDef >.GetNamed( "ReloadWeapon" ), Wielder, parent )
             {
                 playerForced = true
-                
             };
 
             if ( Wielder.drafter != null )
@@ -101,11 +95,6 @@ namespace Combat_Realism
             }
             count = reloaderProp.roundPerMag;
             needReload = false;
-        }
-
-        public override void PostDraw()
-        {
-            // TODO: Reload indicator?
         }
 
         private class GizmoAmmoStatus : Command

--- a/CombatRealism/Reload/JobDriver_Reload.cs
+++ b/CombatRealism/Reload/JobDriver_Reload.cs
@@ -16,9 +16,13 @@ namespace Combat_Realism
         protected override IEnumerable< Toil > MakeNewToils()
         {
             this.FailOnBroken( TargetIndex.A );
-
-            //Toil of do-nothing
-            pawn.stances.SetStance(new Stance_Cooldown(CompReloader.reloaderProp.reloadTick, TargetInfo.Invalid));
+            
+            //Toil of do-nothing		
+            var waitToil = new Toil();
+            waitToil.initAction = () => waitToil.actor.pather.StopDead();
+            waitToil.defaultCompleteMode = ToilCompleteMode.Delay;
+            waitToil.defaultDuration = CompReloader.reloaderProp.reloadTick;
+            yield return waitToil;
 
             //Actual reloader
             var reloadToil = new Toil();


### PR DESCRIPTION
* It seems weapons with short cooldown will override Stance_Cooldown immediately, resulting in super fast reload.
 * Pistols, shotguns, ...
* Thus reverting except _throwMote_ and _playerForced = true_